### PR TITLE
Fixed UIFR-91 so that SimpleObject.fromObject doesn't format nulls, booleans and integers as strings

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/SimpleObject.java
+++ b/api/src/main/java/org/openmrs/ui/framework/SimpleObject.java
@@ -139,8 +139,15 @@ public class SimpleObject extends LinkedHashMap<String, Object> {
 					// deep property: recurse into this
 					ret.put(property, fromObjectHelper(propertyValue, ui, nextLevel, propertiesByLevel));
 				} else {
-					// shallow property: format it
-					ret.put(property, ui.format(propertyValue));
+					// shallow property
+
+					if (propertyValue == null || propertyValue instanceof Boolean || propertyValue instanceof Number) {
+						// is a non-string type that can be represented natively in JSON
+						ret.put(property, propertyValue);
+					}
+					else {
+						ret.put(property, ui.format(propertyValue));
+					}
 				}
 			}
 			return ret;

--- a/api/src/test/java/org/openmrs/ui/framework/SimpleObjectTest.java
+++ b/api/src/test/java/org/openmrs/ui/framework/SimpleObjectTest.java
@@ -39,6 +39,7 @@ public class SimpleObjectTest {
     public void fromObject_shouldCreateSimpleObjectWithNestedProperties() {
 
         Person person = new Person();
+		person.setPersonId(123);
         person.setGender("M");
 
         PersonName name = new PersonName();
@@ -48,13 +49,18 @@ public class SimpleObjectTest {
         name.setPreferred(true);
         person.addName(name);
 
-        String [] properties = {"gender", "personName.givenName", "personName.middleName", "personName.familyName"};
+        String [] properties = {"personId", "gender", "personName.givenName", "personName.middleName", "personName.familyName", "personName.preferred"};
         SimpleObject simplePerson = SimpleObject.fromObject(person, ui, properties);
 
+		Assert.assertEquals(new Integer(123), simplePerson.get("personId"));
         Assert.assertEquals("M", simplePerson.get("gender"));
-        Assert.assertEquals("John", ((Map<String,Object>) simplePerson.get("personName")).get("givenName"));
-        Assert.assertEquals("J", ((Map<String,Object>) simplePerson.get("personName")).get("middleName"));
-        Assert.assertEquals("Johnson", ((Map<String,Object>) simplePerson.get("personName")).get("familyName"));
+
+		Map<String,Object> nameMap = (Map<String,Object>) simplePerson.get("personName");
+
+        Assert.assertEquals("John", nameMap.get("givenName"));
+        Assert.assertEquals("J", nameMap.get("middleName"));
+        Assert.assertEquals("Johnson", nameMap.get("familyName"));
+		Assert.assertTrue((Boolean) nameMap.get("preferred"));
     }
 
     @Test


### PR DESCRIPTION
...eans and integers as strings
