### PR TITLE
UIFR-170: Starting openmrs in debug mode won't work with a customized directory structure

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/UiFrameworkUtil.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiFrameworkUtil.java
@@ -567,19 +567,41 @@ public class UiFrameworkUtil {
 	 */
 	private static boolean addPossibleDevFolder(String baseFolder, String key, Object provider) {
 
+		// Allow a developer to specify the modules directory e.g omod_1.x, mod_2.x.
+		// The default directory is still "omod"
+		String moduleDir = "omod";
+		String fSeparator = File.separator;
+		if (StringUtils.isNotEmpty(baseFolder)) {
+			if (baseFolder.endsWith(fSeparator))
+				baseFolder = baseFolder.substring(0, baseFolder.length() - 1);
+
+			String[] pathSubs = baseFolder.split(fSeparator);
+			if (pathSubs != null && pathSubs.length > 0) {
+				int len = pathSubs.length;
+				String mod = pathSubs[len - 1];
+				if (!mod.contains(key)) {
+					moduleDir = "";
+				}
+			}
+		}
+
 		// Get the appropriate folderPath to check, given the type of provider passed in
-		String folderPath = baseFolder + File.separator + "omod" + File.separator;
+		String folderPath = baseFolder;
+		if(StringUtils.isNotEmpty(moduleDir))
+			folderPath += fSeparator + moduleDir;
+		folderPath += fSeparator;
+		
 		if (provider instanceof ResourceProvider) {
-			folderPath += "src" + File.separator + "main" + File.separator + "webapp" + File.separator + "resources";
+			folderPath += "src" + fSeparator + "main" + fSeparator + "webapp" + fSeparator + "resources";
 		}
 		else if (provider instanceof PageViewProvider) {
-			folderPath += "src" + File.separator + "main" + File.separator + "webapp" + File.separator + "pages";
+			folderPath += "src" + fSeparator + "main" + fSeparator + "webapp" + fSeparator + "pages";
 		}
 		else if (provider instanceof FragmentViewProvider) {
-			folderPath += "src" + File.separator + "main" + File.separator + "webapp" + File.separator + "fragments";
+			folderPath += "src" + fSeparator + "main" + fSeparator + "webapp" + fSeparator + "fragments";
 		}
 		else if (provider instanceof PageControllerProvider || provider instanceof FragmentControllerProvider) {
-			folderPath += "target" + File.separator + "classes";
+			folderPath += "target" + fSeparator + "classes";
 		}
 		else {
 			throw new IllegalArgumentException("Provider is not of an expected type.  Found: " + provider.getClass());


### PR DESCRIPTION
Gives the developer an option to pass a custom directory when starting jetty in debug mode. 
For example: 
mvn jetty:run -DuiFramework.development.openhmis.inventory="/home/andrew/OpenHMIS/openmrs-module-openhmis.inventory/omod_2.x/".

If no directory is appended to the path, then it defaults to "omod".