### PR TITLE
UIFR-206 Add ServletResponse to fragment action controller

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/fragment/FragmentFactory.java
+++ b/api/src/main/java/org/openmrs/ui/framework/fragment/FragmentFactory.java
@@ -424,7 +424,7 @@ public class FragmentFactory {
 		viewProviders.put(key, provider);
 	}
 	
-	public Object invokeFragmentAction(String providerName, String fragmentName, String action, HttpServletRequest httpRequest) {
+	public Object invokeFragmentAction(String providerName, String fragmentName, String action, HttpServletRequest httpRequest, HttpServletResponse httpServletResponse) {
 		log.info("Invoking " + providerName + ":" + fragmentName + " . " + action);
         if ("controller".equals(action)) {
             throw new UiFrameworkException("Illegal to access fragment controller() method as an action");
@@ -463,6 +463,7 @@ public class FragmentFactory {
 		Map<Class<?>, Object> possibleArguments = new LinkedHashMap<Class<?>, Object>();
 		possibleArguments.put(FragmentActionRequest.class, request);
 		possibleArguments.put(HttpServletRequest.class, httpRequest);
+		possibleArguments.put(HttpServletResponse.class, httpServletResponse);
 		possibleArguments.put(HttpSession.class, httpRequest.getSession());
 		possibleArguments.put(UiUtils.class, request.getUiUtils());
 		possibleArguments.put(Session.class, sessionFactory.getSession(httpRequest.getSession()));

--- a/api/src/test/java/org/openmrs/ui/framework/fragment/FragmentFactoryTest.java
+++ b/api/src/test/java/org/openmrs/ui/framework/fragment/FragmentFactoryTest.java
@@ -20,6 +20,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -197,7 +199,23 @@ public class FragmentFactoryTest {
 
         MockHttpServletRequest httpRequest = new MockHttpServletRequest();
         httpRequest.setSession(new MockHttpSession());
-        factory.invokeFragmentAction("test", "test", "action", httpRequest);
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+        factory.invokeFragmentAction("test", "test", "action", httpRequest, httpResponse);
+    }
+
+    @Test
+    public void shouldInjectRequestResponseInToFragmentActionMethod() {
+        factory.addControllerProvider("test", new FragmentControllerProvider() {
+            @Override
+            public Object getController(String id) {
+                return new ActionThatTakeServletRequestResponse();
+            }
+        });
+
+        MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+        httpRequest.setSession(new MockHttpSession());
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+        factory.invokeFragmentAction("test", "test", "action", httpRequest, httpResponse);
     }
 
     @Test(expected = UiFrameworkException.class)
@@ -211,7 +229,8 @@ public class FragmentFactoryTest {
 
         MockHttpServletRequest httpRequest = new MockHttpServletRequest();
         httpRequest.setSession(new MockHttpSession());
-        factory.invokeFragmentAction("test", "test", "hashCode", httpRequest);
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+        factory.invokeFragmentAction("test", "test", "hashCode", httpRequest, httpResponse);
     }
 
     @Test(expected = UiFrameworkException.class)
@@ -225,7 +244,8 @@ public class FragmentFactoryTest {
 
         MockHttpServletRequest httpRequest = new MockHttpServletRequest();
         httpRequest.setSession(new MockHttpSession());
-        factory.invokeFragmentAction("test", "test", "controller", httpRequest);
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+        factory.invokeFragmentAction("test", "test", "controller", httpRequest, httpResponse);
     }
 
 	class MockControllerProvider implements FragmentControllerProvider {
@@ -292,6 +312,14 @@ public class FragmentFactoryTest {
         public FragmentActionResult action(Integer injected, Long notInjected) {
             Assert.assertNotNull("Integer argument was not injected", injected);
             Assert.assertNull("Long argument should not have been injected", notInjected);
+            return new SuccessResult();
+        }
+    }
+
+    public class ActionThatTakeServletRequestResponse {
+        public FragmentActionResult action(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+            Assert.assertNotNull("HttpServletRequest argument was not injected", httpRequest);
+            Assert.assertNotNull("HttpServletResponse argument was not injected", httpResponse);
             return new SuccessResult();
         }
     }

--- a/omod/src/main/java/org/openmrs/module/uiframework/FragmentActionController.java
+++ b/omod/src/main/java/org/openmrs/module/uiframework/FragmentActionController.java
@@ -140,7 +140,7 @@ public class FragmentActionController {
 
 		Object resultObject;
 		try {
-			resultObject = fragmentFactory.invokeFragmentAction(providerName, fragmentName, action, request);
+			resultObject = fragmentFactory.invokeFragmentAction(providerName, fragmentName, action, request, response);
 
 			// Default status code for failures is 400 (BAD REQUEST), successes is 200 (OK)
 			response.setStatus((resultObject instanceof FailureResult) ? 400 : 200);


### PR DESCRIPTION
This adds HttpServletResponse as a possible parameter to fragment action controller.