### PR TITLE
RA-452: Prevent XSS in error messages

### DIFF
--- a/omod/src/main/java/org/openmrs/module/uiframework/PageController.java
+++ b/omod/src/main/java/org/openmrs/module/uiframework/PageController.java
@@ -26,6 +26,7 @@ import org.openmrs.ui.framework.page.Redirect;
 import org.openmrs.ui.framework.session.Session;
 import org.openmrs.ui.framework.session.SessionFactory;
 import org.openmrs.ui.util.ExceptionUtil;
+import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -156,14 +157,14 @@ public class PageController {
             
             StringWriter sw = new StringWriter();
             ex.printStackTrace(new PrintWriter(sw));
-            model.addAttribute("fullStacktrace", sw.toString());
+            model.addAttribute("fullStacktrace", Encode.forHtml(sw.toString()));
 
             Throwable t = ex;
             while (t.getCause() != null && !t.equals(t.getCause()))
                 t = t.getCause();
             sw = new StringWriter();
             t.printStackTrace(new PrintWriter(sw));
-            model.addAttribute("rootStacktrace", sw.toString());
+            model.addAttribute("rootStacktrace", Encode.forHtml(sw.toString()));
 
             return "/module/uiframework/uiError";
         }


### PR DESCRIPTION
**Why**
UI Framework error pages across the refapp may contain user-controlled input in the stack trace. This input should be sanitized to prevent reflected XSS.

**What Changed**
The stack traces outputted to the error pages were sanitized using OWASP HTML encoders.

**Decisions Made**
- Chose to use OWASP because it's a very well supported library and already included as a dependency in the ui-framework module
- Chose to do this in `PageController` because `<c:out>` tags weren't working in `uiError.jsp`. Still not completely sure why, possibly because stack traces were too large?