### PR TITLE
Use openjdk to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: java
 jdk:
- - oraclejdk8
+ - openjdk8 


### PR DESCRIPTION
Looks like the default build distro dropped support for Java 8. Specifying trusty as the build dist seems to fix everything.