### PR TITLE
TRUNK-5898:Add support for JSON MIME Type

### DIFF
--- a/omod/src/main/java/org/openmrs/module/uiframework/ResourceServlet.java
+++ b/omod/src/main/java/org/openmrs/module/uiframework/ResourceServlet.java
@@ -72,7 +72,7 @@ public class ResourceServlet extends HttpServlet {
 		
 		response.setDateHeader("Last-Modified", f.lastModified());
 		response.setContentLength(new Long(f.length()).intValue());
-		String mimeType = getServletContext().getMimeType(f.getName());
+		String mimeType = OpenmrsUtil.getFileMimeType(f);
 		response.setContentType(mimeType);
 		
 		FileInputStream is = new FileInputStream(f);


### PR DESCRIPTION
I  swapping the line `String mimeType = getServletContext().getMimeType(f.getName());` to this:
`String mimeType = OpenmrsUtil.getFileMimeType(f);`
Issue I worked on

https://issues.openmrs.org/browse/TRUNK-5898