### PR TITLE
UIFR-218: Added config.xml GP for uiframework.formatter.timeFormat.

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/UiFrameworkConstants.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiFrameworkConstants.java
@@ -22,7 +22,10 @@ public class UiFrameworkConstants {
     public static final String GP_FORMATTER_DATETIME_FORMAT = "uiframework.formatter.dateAndTimeFormat";
     public static final String GP_FORMATTER_DATE_FORMAT = "uiframework.formatter.dateFormat";
     public static final String GP_FORMATTER_TIME_FORMAT = "uiframework.formatter.timeFormat";
+    public static final String GP_FORMATTER_JS_DATETIME_FORMAT = "uiframework.formatter.JSdateAndTimeFormat";
+    public static final String GP_FORMATTER_JS_DATE_FORMAT = "uiframework.formatter.JSdateFormat";
     
     public static final String MAP_RESOURCE_EXTENSION_POINT_ID = "org.openmrs.ui.framework.mapResource";
+
 
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -58,6 +58,14 @@
         </description>
     </globalProperty>
 
+	<globalProperty>
+		<property>uiframework.formatter.timeFormat</property>
+		<defaultValue>HH:mm:ss</defaultValue>
+		<description>
+			Format used by UiUtils.format for time only.
+		</description>
+	</globalProperty>
+
     <globalProperty>
         <property>uiframework.formatter.dateAndTimeFormat</property>
         <defaultValue>dd.MMM.yyyy, HH:mm:ss</defaultValue>


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/UIFR-218

#### What I have done:
Added missing config.xml GP definition entry for `uiframework.formatter.timeFormat`.
Also added new Java constants for the names
* `uiframework.formatter.JSdateAndTimeFormat`
* `uiframework.formatter.JSdateFormat`