### PR TITLE
Encoded the exception message so that the JavaScript cannot be insert…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
 	<description />
 
 	<dependencies>
-		<!-- Add other dependencies from parent's pom: <dependency> <groupId>org.other.library</groupId> 
+		<!-- Add other dependencies from parent's pom: <dependency> <groupId>org.other.library</groupId>
 			<artifactId>library-name</artifactId> </dependency> -->
 
 		<!-- Begin OpenMRS core -->
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-core-asl</artifactId>
-		</dependency>		
+		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
@@ -74,11 +74,17 @@
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
         </dependency>
-        
+
         <dependency>
            <groupId>org.owasp.encoder</groupId>
            <artifactId>encoder</artifactId>
            <version>1.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>1.2.3</version>
         </dependency>
 
 	</dependencies>

--- a/api/src/main/java/org/openmrs/ui/framework/UiFrameworkException.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiFrameworkException.java
@@ -1,19 +1,24 @@
 package org.openmrs.ui.framework;
 
+import org.owasp.encoder.Encode;
+
 public class UiFrameworkException extends RuntimeException {
-	
+
 	private static final long serialVersionUID = 1L;
-	
+
 	public UiFrameworkException() {
 		super();
 	}
-	
+
 	public UiFrameworkException(String message) {
-		super(message);
+		super(getEncodedMessage(message));
 	}
-	
+
 	public UiFrameworkException(String message, Throwable throwable) {
-		super(message, throwable);
+		super(getEncodedMessage(message), throwable);
 	}
-	
+
+	private static String getEncodedMessage(String message) {
+		return message == null ? null : Encode.forHtml(message);
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <target>1.6</target>
-                        <source>1.6</source>
+                        <target>1.8</target>
+                        <source>1.8</source>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
…ed into it via the request parameters. Sometimes the request parameters are sent back in the error response.

e.g. /openmrs/coreapp%3Cimg%20src=a%20onerror=alert(1)%3E/findpatient/findPatient.page