### PR TITLE
UIFR-220 Format date without timezone conversion

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -397,7 +397,20 @@ public abstract class UiUtils {
 			return format(dateExt.getDateWithoutTime());
 		}
 	}
-	
+
+	/**
+	 * Formats a date without any timezone conversion
+	 *
+	 * @param date the date to format
+	 * @return date formatted
+	 */
+	public String formatDateWithoutTimezoneConversion(Date date) {
+		String dateFormatGP = Context.getAdministrationService()
+				.getGlobalProperty(UiFrameworkConstants.GP_FORMATTER_DATE_FORMAT, "dd.MMM.yyyy");
+		SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatGP, Context.getLocale());
+		return dateFormat.format(date);
+	}
+
 	/**
 	 * Formats a date with this format: dd MMM yyyy hh:mm a
 	 * 

--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -405,9 +405,7 @@ public abstract class UiUtils {
 	 * @return date formatted
 	 */
 	public String formatDateWithoutTimezoneConversion(Date date) {
-		String dateFormatGP = Context.getAdministrationService()
-				.getGlobalProperty(UiFrameworkConstants.GP_FORMATTER_DATE_FORMAT, "dd.MMM.yyyy");
-		SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatGP, Context.getLocale());
+		SimpleDateFormat dateFormat = new SimpleDateFormat(getDateFormat(), Context.getLocale());
 		return dateFormat.format(date);
 	}
 


### PR DESCRIPTION
Issue: [UIFR-220](https://issues.openmrs.org/browse/UIFR-220)

Add a new method to format dates without timezone conversion, even when the timezone GP is true. 