### PR TITLE
(chore) UIFR-224: Simplify GitHub Action with Matrix Strategy

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,47 +8,25 @@ on:
     branches: [ "master" ]
 
 jobs:
-  java-8:
-
+  build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java-version: [8, 11, 17]
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
           cache: maven
-      - name: Build with Maven
-        run: mvn clean install --file pom.xml
-
-  java-11:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: maven
-      - name: Build with Maven
-        run: mvn clean install --file pom.xml
-
-  java-17:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-          cache: maven
+      
+      - name: Display Java version
+        run: java -version
+        
       - name: Build with Maven
         run: mvn clean install --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,9 +24,6 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
           cache: maven
-      
-      - name: Display Java version
-        run: java -version
         
       - name: Build with Maven
         run: mvn clean install --file pom.xml


### PR DESCRIPTION
This is the implementation of  a matrix strategy to run the builds with multiple Java versions in a single job. 

The current GitHub Action configuration for the openmrs-module-uiframework repository uses separate jobs for building the project with different Java versions (8, 11, and 17). This can be simplified by using a matrix strategy to reduce redundancy and improve maintainability.

https://openmrs.atlassian.net/browse/UIFR-224