### PR TITLE
Update user property clientTimezone only if changed

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -683,9 +683,14 @@ public abstract class UiUtils {
 	public void setClientTimezone(String clientTimezone) {
 		try {
 			Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-			Context.getUserService().setUserProperty(Context.getAuthenticatedUser(),
-			    Context.getAdministrationService().getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE),
-			    clientTimezone);
+
+			String propertyName = Context.getAdministrationService()
+					.getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
+			String currentClientTimezone = Context.getAuthenticatedUser().getUserProperty(propertyName);
+
+			if (currentClientTimezone == null || !currentClientTimezone.equals(clientTimezone)) {
+				Context.getUserService().setUserProperty(Context.getAuthenticatedUser(), propertyName, clientTimezone);
+			}
 		}
 		finally {
 			Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);


### PR DESCRIPTION
This modification ensures that clientTimezone global property is only updated when the new value differs from existing one. This avoids overhead caused by unnecessary writes as the method is frequently called with the same value on each page refresh.