### PR TITLE
escapeJs vulnerable to XSS

### DIFF
--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -478,11 +478,11 @@ public abstract class UiUtils {
 			return null;
 		}
 		
-         input.replace("\\", "\\\\");
-         input.replace("\n", "\\n");
-         input.replace("\r", "\\r");
-         input.replace("'", "\\'");
-         input.replace("\"", "\\\"");
+		input = input.replace("\\", "\\\\");
+		input = input.replace("\n", "\\n");
+		input = input.replace("\r", "\\r");
+		input = input.replace("'", "\\'");
+		input = input.replace("\"", "\\\"");
 		return input;
 	}
 	

--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -477,7 +477,10 @@ public abstract class UiUtils {
 		if (input == null) {
 			return null;
 		}
+		
+		input = input.replaceAll("\\\\", "\\\\\\\\");
 		input = input.replaceAll("\n", "\\\\n");
+		input = input.replaceAll("\r", "\\\\r");
 		input = input.replaceAll("'", "\\\\'");
 		input = input.replaceAll("\"", "\\\\\"");
 		return input;
@@ -683,11 +686,11 @@ public abstract class UiUtils {
 	public void setClientTimezone(String clientTimezone) {
 		try {
 			Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-
+			
 			String propertyName = Context.getAdministrationService()
-					.getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
+			        .getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
 			String currentClientTimezone = Context.getAuthenticatedUser().getUserProperty(propertyName);
-
+			
 			if (currentClientTimezone == null || !currentClientTimezone.equals(clientTimezone)) {
 				Context.getUserService().setUserProperty(Context.getAuthenticatedUser(), propertyName, clientTimezone);
 			}

--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -478,11 +478,11 @@ public abstract class UiUtils {
 			return null;
 		}
 		
-         input.replace("\\", "\\\\")
-         input.replace("\n", "\\n")
-         input.replace("\r", "\\r")
-         input.replace("'", "\\'")
-         input.replace("\"", "\\\"")
+         input.replace("\\", "\\\\");
+         input.replace("\n", "\\n");
+         input.replace("\r", "\\r");
+         input.replace("'", "\\'");
+         input.replace("\"", "\\\"");
 		return input;
 	}
 	
@@ -686,7 +686,8 @@ public abstract class UiUtils {
 	public void setClientTimezone(String clientTimezone) {
 		try {
 			Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-			String propertyName = Context.getAdministrationService().getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
+			String propertyName = Context.getAdministrationService()
+			        .getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
 			String currentClientTimezone = Context.getAuthenticatedUser().getUserProperty(propertyName);
 			if (currentClientTimezone == null || !currentClientTimezone.equals(clientTimezone)) {
 				Context.getUserService().setUserProperty(Context.getAuthenticatedUser(), propertyName, clientTimezone);

--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -686,11 +686,8 @@ public abstract class UiUtils {
 	public void setClientTimezone(String clientTimezone) {
 		try {
 			Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-			
-			String propertyName = Context.getAdministrationService()
-			        .getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
+			String propertyName = Context.getAdministrationService().getGlobalProperty(UiFrameworkConstants.UP_CLIENT_TIMEZONE);
 			String currentClientTimezone = Context.getAuthenticatedUser().getUserProperty(propertyName);
-			
 			if (currentClientTimezone == null || !currentClientTimezone.equals(clientTimezone)) {
 				Context.getUserService().setUserProperty(Context.getAuthenticatedUser(), propertyName, clientTimezone);
 			}

--- a/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
+++ b/api/src/main/java/org/openmrs/ui/framework/UiUtils.java
@@ -478,11 +478,11 @@ public abstract class UiUtils {
 			return null;
 		}
 		
-		input = input.replaceAll("\\\\", "\\\\\\\\");
-		input = input.replaceAll("\n", "\\\\n");
-		input = input.replaceAll("\r", "\\\\r");
-		input = input.replaceAll("'", "\\\\'");
-		input = input.replaceAll("\"", "\\\\\"");
+         input.replace("\\", "\\\\")
+         input.replace("\n", "\\n")
+         input.replace("\r", "\\r")
+         input.replace("'", "\\'")
+         input.replace("\"", "\\\"")
 		return input;
 	}
 	

--- a/api/src/test/java/org/openmrs/ui/framework/UiUtilsTest.java
+++ b/api/src/test/java/org/openmrs/ui/framework/UiUtilsTest.java
@@ -129,9 +129,9 @@ public class UiUtilsTest {
 	
 	@Test
 	public void escapeJs_shouldPreventXSSViaBackslashInjection() {
-		// exact payload from the bug report
-		String result = ui.escapeJs("Foo \\\"}];alert(0);[// Bar");
-		Assert.assertTrue(result.contains("\\\\")); // backslash must be doubled
+        String input = "Foo \\\"}];alert(0);[// Bar";
+        String expected = "Foo \\\\\\\"}];alert(0);[// Bar";
+        Assert.assertEquals(expected, ui.escapeJs(input));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/ui/framework/UiUtilsTest.java
+++ b/api/src/test/java/org/openmrs/ui/framework/UiUtilsTest.java
@@ -122,4 +122,26 @@ public class UiUtilsTest {
 		
 	}
 	
+	@Test
+	public void escapeJs_shouldEscapeBackslash() {
+		Assert.assertEquals("Foo \\\\", ui.escapeJs("Foo \\"));
+	}
+	
+	@Test
+	public void escapeJs_shouldPreventXSSViaBackslashInjection() {
+		// exact payload from the bug report
+		String result = ui.escapeJs("Foo \\\"}];alert(0);[// Bar");
+		Assert.assertTrue(result.contains("\\\\")); // backslash must be doubled
+	}
+	
+	@Test
+	public void escapeJs_shouldEscapeDoubleQuote() {
+		Assert.assertEquals("say \\\"hi\\\"", ui.escapeJs("say \"hi\""));
+	}
+	
+	@Test
+	public void escapeJs_shouldReturnNullForNullInput() {
+		Assert.assertNull(ui.escapeJs(null));
+	}
+	
 }

--- a/api/src/test/java/org/openmrs/ui/framework/UiUtilsTest.java
+++ b/api/src/test/java/org/openmrs/ui/framework/UiUtilsTest.java
@@ -129,9 +129,9 @@ public class UiUtilsTest {
 	
 	@Test
 	public void escapeJs_shouldPreventXSSViaBackslashInjection() {
-        String input = "Foo \\\"}];alert(0);[// Bar";
-        String expected = "Foo \\\\\\\"}];alert(0);[// Bar";
-        Assert.assertEquals(expected, ui.escapeJs(input));
+		String input = "Foo \\\"}];alert(0);[// Bar";
+		String expected = "Foo \\\\\\\"}];alert(0);[// Bar";
+		Assert.assertEquals(expected, ui.escapeJs(input));
 	}
 	
 	@Test


### PR DESCRIPTION
### Issue I worked on

https://openmrs.atlassian.net/browse/RA-1424

### Summary

The escapeJs method in UiUtils.java did not escape backslashes, making it vulnerable to XSS. A crafted input like Foo \"}];alert(0);[// injected into a JS string context (e.g., the breadcrumb in editSection.gsp) could break out of the string and execute arbitrary JavaScript.

### Fix

- Added backslash escaping as the first replacement in escapeJs (order is critical — it must run before other replacements add new backslashes)
- Also added \r escaping which was previously missing.
- 4 New small test cases are also aded for better security checking.

**Note**: The vulnerable rendering surface is editSelection.gsp in openmrs-module-registrationapp, which calls ui.escapeJs(ui.format(patient)). No change is needed there — this fix protects it automatically.

<img width="1911" height="441" alt="Screenshot 2026-03-19 220420" src="https://github.com/user-attachments/assets/f239d4a4-e627-4be0-9367-3dcfd8e469a0" />
